### PR TITLE
deps: update LangChain4j and MCP versions to 1.16.2 and 1.16.2-beta26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
     <java.version>21</java.version>
     <spring.boot.version>4.0.1</spring.boot.version>
     <!-- Set the LangChain4j version to a recent stable release -->
-    <langchain4j.version>1.16.1</langchain4j.version>
+    <langchain4j.version>1.16.2</langchain4j.version>
     <!-- MCP support requires beta version -->
-    <langchain4j.mcp.version>1.16.1-beta26</langchain4j.mcp.version>
+    <langchain4j.mcp.version>1.16.2-beta26</langchain4j.mcp.version>
     <!-- Test dependency versions - JUnit version managed by Spring Boot BOM -->
     <assertj.version>3.27.7</assertj.version>
     <testcontainers.version>2.0.2</testcontainers.version>


### PR DESCRIPTION
## Summary

Bumps the LangChain4j dependencies to the latest releases:

- `langchain4j.version`: `1.16.1` → `1.16.2`
- `langchain4j.mcp.version`: `1.16.1-beta26` → `1.16.2-beta26`

This is a single-line change in the root [`pom.xml`](pom.xml); all child modules inherit the versions via the parent, so no other files needed updating.

## Testing

Built all 6 modules (`mvn clean package`) and verified each one live against Azure OpenAI (`gpt-5.2`):

| Module | Verification |
|--------|--------------|
| 01 — Introduction | Simple chat round-trip ✓ |
| 02 — Prompt Engineering | Low-eagerness pattern (`15% of 200 = 30`) ✓ |
| 03 — RAG | Document upload → embeddings → grounded answer with sources ✓ |
| 04 — Tools | Agent tool call (`100°F = 37.8°C`) ✓ |
| 05 — MCP | Stdio filesystem demo + Supervisor agentic demo ✓ |

Module 00 (quick-start) compiled successfully (uses GitHub Models, not exercised live).
